### PR TITLE
Add support to Rust

### DIFF
--- a/Edit/Modules/SyntaxService/LanguageDataStore.swift
+++ b/Edit/Modules/SyntaxService/LanguageDataStore.swift
@@ -85,7 +85,7 @@ extension LanguageDataStore {
 		}
 
 		Task {
-			_ = try! await loadLanguageConfiguration(with: utType, identifier: identifier)
+			_ = try? await loadLanguageConfiguration(with: utType, identifier: identifier)
 		}
 
 		return nil

--- a/Edit/Modules/SyntaxService/LanguageProfile+Profiles.swift
+++ b/Edit/Modules/SyntaxService/LanguageProfile+Profiles.swift
@@ -55,6 +55,10 @@ extension LanguageProfile {
 		if utType.conforms(to: .rubyScript) {
 			return LanguageProfile.rubyProfile
 		}
+		
+		if utType.conforms(to: .rustSource) {
+			return LanguageProfile.rustProfile
+		}
 
 		if utType.conforms(to: .swiftSource) {
 			return LanguageProfile.swiftProfile
@@ -140,6 +144,11 @@ extension LanguageProfile {
 	static let swiftProfile = LanguageProfile(
 		RootLanguage.swift,
 		language: Language(tree_sitter_swift())
+	)
+
+	static let rustProfile = LanguageProfile(
+		RootLanguage.rust,
+		language: Language(tree_sitter_rust())
 	)
 
 	static let genericProfile = LanguageProfile(


### PR DESCRIPTION
# Description

A simple addition to the code using existing references to provide support for the Rust language.

Additionally, replace a force-try in the `LanguageDataStore` that was causing the app to crash when opening a Rust file.

---

This PR checks one item in the todo list of the issue #20.